### PR TITLE
fix: avatar ratio in the infowindow of map

### DIFF
--- a/src/components/GoogleMap/GoogleMap.css
+++ b/src/components/GoogleMap/GoogleMap.css
@@ -44,6 +44,8 @@
 .Avatar_Container img {
   border-radius: 50%;
   width: 75px;
+  height: 75px;
+  object-fit: cover;
 }
 
 .Marker_Distance {


### PR DESCRIPTION
This fixed the bug that sometimes the avatar of the petsitter in the infowindow of google map is not round if the original avatar image is not round.

![1681563229910](https://user-images.githubusercontent.com/88971435/232224850-9d6c6626-e15a-4389-ae94-37fb832f930e.png)
